### PR TITLE
junos-home-setup.md: tcp-mss should to 1432 when enable ipv6

### DIFF
--- a/content/posts/junos-home-setup.md
+++ b/content/posts/junos-home-setup.md
@@ -152,7 +152,10 @@ set interfaces pp0 unit 0 pppoe-options ignore-eol-tag
 set interfaces pp0 unit 0 family inet mtu 1492
 set interfaces pp0 unit 0 family inet negotiate-address
 set routing-options static route 0.0.0.0/0 next-hop pp0.0
-set security flow tcp-mss all-tcp mss 1452
+# IPv4 Only
+#set security flow tcp-mss all-tcp mss 1452
+# IPv4 and IPv6
+set security flow tcp-mss all-tcp mss 1432
 set security zones security-zone untrust interfaces ge-0/0/0.0
 set security zones security-zone untrust interfaces pp0.0
 


### PR DESCRIPTION
这里1452在ipv6设置下要减去20个字节变成1432.
之前ipv6环境下简书时而可以访问时而不能访问的root cause找到了，原因是PMTU黑洞，其细节如下：
终端设备在发包时，也可以设置 DF （ Don't Fragment ）标记来告诉路由器不要分片。这时中间路由器会丢掉超过 MTU 的包，回复一条 ICMP Fragmentation Needed 消息。发送者收到这个包后，下次就会发小一点的包，这个过程叫做 PMTU Discovery 。现实中可以看到 HTTPS （ TLS ）的流量大都是带 DF 标记的。
然而，互联网上有大量的中间设备为了所谓的“安全”或者没有正确配置，不回应 ICMP Fragmentation Needed 包，这使得访问某些网站时如果某个包的大小超过了 PMTU，会被无声地丢弃，直到 TCP 协议发现超时丢包进行重传，这非常缓慢。遇到这种情况，我们可以说你和目标服务器的路径上存在 PMTU 黑洞。
由于我们到简书之间的目标链路一直在变化，在链路节点中如果遇到了这种被错误配置的设备，就会导致我们无法访问简书。
现在国内 ISP 一般都是通过 PPPoE 虚拟拨号建立 WAN 口连接的。Ethernet 的默认 MTU 是 1500，但是 PPPoE 隧道有 8 个 bytes 的开销，所以 PPPoE 虚连接的 MTU 就是 1500-8=1492，减掉 IPv4 包头（ 20 字节）和 TCP 包头（ 20 字节），可以得知 IPv4 下需要把 MSS 设为 1452 以下。IPv6 的包头是 40 字节，所以 IPv6 下需要把 MSS 设为 1432 以下。
解决方法：
#set security flow tcp-mss all-tcp mss 1452
set security flow tcp-mss all-tcp mss 1432
原先的设置值是1452, 改成1432后，强制丢包现象消失，原先无法访问的简书可以被访问了。